### PR TITLE
Backport some changes from #29 + regex SvgSize

### DIFF
--- a/.brackets.json
+++ b/.brackets.json
@@ -1,5 +1,13 @@
 {
     "spaceUnits": 2,
     "useTabChar": false,
-    "linting.enabled": true
+    "linting.enabled": true,
+    "linting.prefer": [
+        "HTMLHint",
+        "CSSLint",
+        "JSHint",
+        "JSCS",
+        "JSONLint"
+    ],
+    "linting.usePreferredOnly": true
 }

--- a/.jscs.json
+++ b/.jscs.json
@@ -46,7 +46,7 @@
   },
 
   "maximumLineLength": {
-    "value": 125,
+    "value": 145,
     "allowComments":  true,
     "allowRegex": true
   }

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,6 +1,5 @@
 {
   "indent"     : 2,
-  "maxlen"     : 125,
   "browser"    : true,
   "jquery"     : true,
   "node"       : true,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,4 @@
-module.exports = function(grunt) {
+module.exports = function (grunt) {
   "use strict";
   grunt.initConfig({
     pkg: grunt.file.readJSON("package.json"),
@@ -51,7 +51,7 @@ module.exports = function(grunt) {
 
   require("matchdep").filterDev("grunt-*").forEach(grunt.loadNpmTasks);
 
-  grunt.registerTask("default", "List of commands", function() {
+  grunt.registerTask("default", "List of commands", function () {
     grunt.log.writeln("");
     grunt.log.writeln("Run 'grunt lint' to lint the source files");
   });

--- a/css/style.css
+++ b/css/style.css
@@ -46,9 +46,7 @@
   height: 240px;
 }
 
-/* Slight shadow around image */
 .html-skeleton-img-shadow { box-shadow: 0 0 3px #000; }
-.html-skeleton-img-shadow-dark { box-shadow: 0 0 2px 1px #fff; }
 
 /* Shift the dialog content (excluding the image) up */
 .html-skeleton-content {

--- a/main.js
+++ b/main.js
@@ -270,17 +270,16 @@ define(function (require, exports, module) {
 
   /**
    * @private
-   * Open the file browse dialog for the user to select an image
+   * Open the file browse dialog for the user to select an image.
+   * @param {Object} e DOM event.
    */
   function _showFileDialog(e) {
-    FileSystem.showOpenDialog(
-      false, false, Strings.FILE_DIALOG_TITLE,
-      "", ImageFiles, function (closedDialog, selectedFile) {
-        if (!closedDialog && selectedFile && selectedFile.length > 0) {
-          _displayImage(selectedFile[0]);
-        }
+    FileSystem.showOpenDialog(false, false, Strings.FILE_DIALOG_TITLE,
+                              "", ImageFiles, function (cancel, selected) {
+      if (!cancel && selected && selected.length > 0) {
+        _displayImage(selected[0]);
       }
-    );
+    });
     e.preventDefault();
     e.stopPropagation();
   }

--- a/main.js
+++ b/main.js
@@ -27,7 +27,7 @@ define(function (require, exports, module) {
       PreferencesManager = brackets.getModule("preferences/PreferencesManager"),
       ProjectManager     = brackets.getModule("project/ProjectManager"),
 
-      ImageFiles         = LanguageManager.getLanguage("image")._fileExtensions.push("svg"),
+      ImageFiles         = LanguageManager.getLanguage("image")._fileExtensions.concat("svg"),
       Strings            = require("strings"),
       SvgSize            = require("src/SvgSize"),
       IndentSize         = require("src/IndentSize"),
@@ -268,7 +268,6 @@ define(function (require, exports, module) {
     return;
   }
 
-
   /**
    * @private
    * Open the file browse dialog for the user to select an image
@@ -276,7 +275,7 @@ define(function (require, exports, module) {
   function _showFileDialog(e) {
     FileSystem.showOpenDialog(
       false, false, Strings.FILE_DIALOG_TITLE,
-      null, ImageFiles, function (closedDialog, selectedFile) {
+      "", ImageFiles, function (closedDialog, selectedFile) {
         if (!closedDialog && selectedFile && selectedFile.length > 0) {
           _displayImage(selectedFile[0]);
         }
@@ -285,7 +284,6 @@ define(function (require, exports, module) {
     e.preventDefault();
     e.stopPropagation();
   }
-
 
   /**
    * Display HTML Skeleton dialog box

--- a/nls/de/strings.js
+++ b/nls/de/strings.js
@@ -1,25 +1,12 @@
 /*
-* Copyright (c) 2012 Adobe Systems Incorporated. All rights reserved.
-*
-* Permission is hereby granted, free of charge, to any person obtaining a
-* copy of this software and associated documentation files (the "Software"),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in
-* all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
-*
-*/
+ * HTML Skeleton
+ * Created 2014-2015 Triangle717
+ * <http://le717.github.io/>
+ *
+ * Licensed under The MIT License
+ * <http://opensource.org/licenses/MIT/>
+ */
+
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
 /*global define */
@@ -47,7 +34,7 @@ define({
     "FULL_SKELETON"                : "Komplettes HTML Grundgerüst",
     "FULL_SKELETON_DESCRIPTION"    : "Enthält alle obigen Elemente, außer Inline-Stylesheet, Inline-Script und Grafik/Bild",
     "BTN_CANCEL"                   : "Abbrechen",
-    "BTN_DONE"                     : "Fertig",
+    "BTN_DONE"                     : "Fertig"
 });
 
 /* Last translated for d04d101774e59251f89e36f83a261e988b4e39b8 */

--- a/nls/it/strings.js
+++ b/nls/it/strings.js
@@ -1,25 +1,12 @@
 /*
-* Copyright (c) 2012 Adobe Systems Incorporated. All rights reserved.
-*
-* Permission is hereby granted, free of charge, to any person obtaining a
-* copy of this software and associated documentation files (the "Software"),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in
-* all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
-*
-*/
+ * HTML Skeleton
+ * Created 2014-2015 Triangle717
+ * <http://le717.github.io/>
+ *
+ * Licensed under The MIT License
+ * <http://opensource.org/licenses/MIT/>
+ */
+
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
 /*global define */
@@ -49,6 +36,6 @@ define({
     "FULL_SKELETON_DESCRIPTION"    : "Comprende tutti gli elementi sopra indicati, salvo foglio di stile interno, script interno, e immagine",
     "BTN_CANCEL"                   : "Cancella",
     "BTN_DONE"                     : "Fatto",
-    "BTN_BROWSE"                   : "Sfoglia\u2026",
+    "BTN_BROWSE"                   : "Sfoglia\u2026"
 });
 /* Last translated for 53ba9106af6ec36af1400f95417498a05f6e277a */

--- a/nls/root/strings.js
+++ b/nls/root/strings.js
@@ -1,25 +1,12 @@
 /*
-* Copyright (c) 2012 Adobe Systems Incorporated. All rights reserved.
-*
-* Permission is hereby granted, free of charge, to any person obtaining a
-* copy of this software and associated documentation files (the "Software"),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in
-* all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
-*
-*/
+ * HTML Skeleton
+ * Created 2014-2015 Triangle717
+ * <http://le717.github.io/>
+ *
+ * Licensed under The MIT License
+ * <http://opensource.org/licenses/MIT/>
+ */
+
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
 /*global define */
@@ -50,5 +37,5 @@ define({
   "FULL_SKELETON_DESCRIPTION"    : "Includes all elements above except inline stylesheet, inline script, and image",
   "BTN_CANCEL"                   : "Cancel",
   "BTN_DONE"                     : "Done",
-  "BTN_BROWSE"                   : "Browse\u2026",
+  "BTN_BROWSE"                   : "Browse\u2026"
 });

--- a/nls/strings.js
+++ b/nls/strings.js
@@ -1,25 +1,12 @@
 /*
-* Copyright (c) 2012 Adobe Systems Incorporated. All rights reserved.
-*
-* Permission is hereby granted, free of charge, to any person obtaining a
-* copy of this software and associated documentation files (the "Software"),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in
-* all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
-*
-*/
+ * HTML Skeleton
+ * Created 2014-2015 Triangle717
+ * <http://le717.github.io/>
+ *
+ * Licensed under The MIT License
+ * <http://opensource.org/licenses/MIT/>
+ */
+
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
 /*global define */

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
   "name": "le717.html-skeleton",
-  "version": "1.3.5",
+  "version": "1.4.0",
   "title": "HTML Skeleton",
   "description": "Insert a variety of HTML elements into your document with ease.",
   "homepage": "https://github.com/le717/brackets-html-skeleton",
-  "version": "1.3.5",
   "author": "Triangle717 (http://le717.github.io)",
   "license": "MIT",
   "engines": { "brackets": ">=0.44.0" },

--- a/src/IndentSize.js
+++ b/src/IndentSize.js
@@ -11,7 +11,7 @@
  */
 
 
-define(function(require, exports, module) {
+define(function (require, exports, module) {
   "use strict";
   var PreferencesManager = brackets.getModule("preferences/PreferencesManager");
 
@@ -22,7 +22,6 @@ define(function(require, exports, module) {
     size: 2,
     isTab: false
   };
-
 
   /**
    * @private
@@ -35,7 +34,6 @@ define(function(require, exports, module) {
     return new Array(num + 1).join(str);
   }
 
-
   /**
    * Create a complete indentation level by repeating
    * the user's desired character by their chosen size.
@@ -44,7 +42,6 @@ define(function(require, exports, module) {
   function getIndentation() {
     return _repeatString(indentation.char, indentation.size);
   }
-
 
   /**
    * Get the current indentation settings for use in inserted code
@@ -64,7 +61,6 @@ define(function(require, exports, module) {
     return indentation.char;
   }
 
-
   /**
    * Get the user's indentation level size depending on if they use spaces or tabs.
    * @return {String} Indentation level size.
@@ -74,9 +70,8 @@ define(function(require, exports, module) {
     return indentation.size;
   }
 
-
   // A relevant preference was changed, update our settings
-  PreferencesManager.on("change", function(e, data) {
+  PreferencesManager.on("change", function (e, data) {
     if (data.ids.indexOf("useTabChar") > -1) {
       getIndentType();
     }
@@ -85,7 +80,6 @@ define(function(require, exports, module) {
       getIndentSize();
     }
   });
-
 
   exports.getIndentType   = getIndentType;
   exports.getIndentSize   = getIndentSize;

--- a/src/IndentSize.js
+++ b/src/IndentSize.js
@@ -3,7 +3,7 @@
 
 /*
  * HTML Skeleton
- * Created 2014 Triangle717
+ * Created 2014-2015 Triangle717
  * <http://le717.github.io/>
  *
  * Licensed under The MIT License
@@ -11,35 +11,35 @@
  */
 
 
- define(function (require, exports, module) {
+define(function(require, exports, module) {
   "use strict";
-   var PreferencesManager = brackets.getModule("preferences/PreferencesManager");
+  var PreferencesManager = brackets.getModule("preferences/PreferencesManager");
 
-   // Store the indentation values,
-   // initializing them as 2 space indentation
-   var indentation = {
-     char: "\u0020",
-     size: 2,
-     isTab: false
-   };
+  // Store the indentation values,
+  // initializing them as 2 space indentation
+  var indentation = {
+    char: "\u0020",
+    size: 2,
+    isTab: false
+  };
 
 
   /**
    * @private
-   * Polyfill from http://stackoverflow.com/a/4550005
-   * @param str Text to be repeated.
-   * @param num Number of times text should be repeated.
-   * @return {string} repeated the number of times stated.
+   * Helper from http://stackoverflow.com/a/4550005
+   * @param {String} str Text to be repeated.
+   * @param {Number} num Number of times text repeated should occur.
+   * @returns {String}
    */
   function _repeatString(str, num) {
-    return (new Array(num + 1)).join(str);
+    return new Array(num + 1).join(str);
   }
 
 
   /**
    * Create a complete indentation level by repeating
    * the user's desired character by their chosen size.
-   * @return {string} Complete indentation level.
+   * @return {String} Complete indentation level.
    */
   function getIndentation() {
     return _repeatString(indentation.char, indentation.size);
@@ -48,7 +48,7 @@
 
   /**
    * Get the current indentation settings for use in inserted code
-   * @return {string} User's current indentation settings
+   * @return {String} User's current indentation settings
    */
   function getIndentType() {
     // \u0009 is a tab, \u0020 is a space
@@ -65,30 +65,29 @@
   }
 
 
-   /**
-    * Get the user's indentation level size depending on if they use spaces or tabs.
-    * @return {string} Indentation level size.
-    */
-   function getIndentSize() {
-     indentation.size = indentation.isTab ? PreferencesManager.get("tabSize") : PreferencesManager.get("spaceUnits");
-     return indentation.size;
-   }
+  /**
+   * Get the user's indentation level size depending on if they use spaces or tabs.
+   * @return {String} Indentation level size.
+   */
+  function getIndentSize() {
+    indentation.size = indentation.isTab ? PreferencesManager.get("tabSize") : PreferencesManager.get("spaceUnits");
+    return indentation.size;
+  }
 
 
   // A relevant preference was changed, update our settings
-  PreferencesManager.on("change", function (e, data) {
-    data.ids.forEach(function (value) {
-      if (value === "useTabChar") {
-        getIndentType();
-      } else if (value === "tabSize" || value === "spaceUnits") {
-        getIndentSize();
-      }
-    });
+  PreferencesManager.on("change", function(e, data) {
+    if (data.ids.indexOf("useTabChar") > -1) {
+      getIndentType();
+    }
+
+    if (data.ids.indexOf("tabSize") > -1 || data.ids.indexOf("spaceUnits") > -1) {
+      getIndentSize();
+    }
   });
 
 
-   exports.indentation     = indentation;
-   exports.getIndentType   = getIndentType;
-   exports.getIndentSize   = getIndentSize;
-   exports.getIndentation  = getIndentation;
- });
+  exports.getIndentType   = getIndentType;
+  exports.getIndentSize   = getIndentSize;
+  exports.getIndentation  = getIndentation;
+});

--- a/src/IndentSize.js
+++ b/src/IndentSize.js
@@ -11,7 +11,7 @@
  */
 
 
-define(function (require, exports, module) {
+define(function (require, exports) {
   "use strict";
   var PreferencesManager = brackets.getModule("preferences/PreferencesManager");
 

--- a/src/SvgSize.js
+++ b/src/SvgSize.js
@@ -11,7 +11,7 @@
  */
 
 
-define(function (require, exports, module) {
+define(function (require, exports) {
   "use strict";
   var FileSystem = brackets.getModule("filesystem/FileSystem"),
       FileUtils  = brackets.getModule("file/FileUtils");

--- a/strings.js
+++ b/strings.js
@@ -1,25 +1,12 @@
 /*
-* Copyright (c) 2012 Adobe Systems Incorporated. All rights reserved.
-*
-* Permission is hereby granted, free of charge, to any person obtaining a
-* copy of this software and associated documentation files (the "Software"),
-* to deal in the Software without restriction, including without limitation
-* the rights to use, copy, modify, merge, publish, distribute, sublicense,
-* and/or sell copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in
-* all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-* DEALINGS IN THE SOFTWARE.
-*
-*/
+ * HTML Skeleton
+ * Created 2014-2015 Triangle717
+ * <http://le717.github.io/>
+ *
+ * Licensed under The MIT License
+ * <http://opensource.org/licenses/MIT/>
+ */
+
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
 /*global define */


### PR DESCRIPTION
The `issue-26` branch (#29) contains a lot of changes I eventually want to complete, but due to architectural changes and issues I have not yet completed it. This PR backports some of many changes made on that branch, with the rest of the changes must remain unreleased for now.

The biggest change is rewriting the entire **src/SvgSize.js** module to use simple regexs to extract the sizes instead of using jQuery and the DOM to do it. Using regexs for this module was actually my original plan... but I was unable to do it until now.